### PR TITLE
Don't replace whitespace sequences with a single space within an entry.

### DIFF
--- a/src/xml_tok.c
+++ b/src/xml_tok.c
@@ -157,7 +157,7 @@ void init_statetable(void){
 	a(s_entity,NULL,		0,255,			c_eat+c_store,	s_entity);
 	r(s_entitydone,	t_entity,								s_start);
 
-	a(s_word,		c_ws,	0,0,			c_nil,			s_worddone);
+	a(s_word,		c_ws,	0,0,			c_eat+c_store,			s_word);
 	a(s_word,		"<&",	0,0,			c_nil,			s_worddone);
 	a(s_word,		NULL,	0,255,			c_eat+c_store,	s_word);
 	r(s_worddone,	t_word,									s_start);


### PR DESCRIPTION
hnb's XML parser collapses common whitespace chars into single space on read. For instance, string "foo    bar" will be properly displayed and written to .xml file as a hnb entry, but when read it will be collapsed to "foo bar" (and will overwrite the old one, when written to file).

The parser is a state machine. This commit introduces the following: if the parses is in state s_word and encounters whitespace, it stores the whitespace as part of the word and remains in the s_word state. Works for me, though I can't guarantee not having any side effects.
